### PR TITLE
Linux Wayland fixes

### DIFF
--- a/start-linux.sh
+++ b/start-linux.sh
@@ -1,4 +1,16 @@
+#!/bin/sh
 # Set library path for SNAP packages (Ubuntu support)
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/snap/vlc/current/usr/lib
 
-java -Xms1024m -Xmx1024m -jar GuideMe.jar
+JAVA_OPTS="-Xms1024m -Xmx1024m"
+
+if [ "${XDG_SESSION_TYPE-}" = "wayland" ]; then
+	# GDK_BACKEND=x11 required for GUI to start on wayland
+	GDK_BACKEND="x11"
+	export GDK_BACKEND
+	# Disable X initialization in VLCJ to avoid SIGSEGV on wayland
+	JAVA_OPTS="${JAVA_OPTS} -DVLCJ_INITX=no"
+fi
+
+java ${JAVA_OPTS} \
+	-jar GuideMe.jar


### PR DESCRIPTION
Conditionally enable the following Wayland workarounds in the start
script if Wayland is detected:

* Set environment variable `GDK_BACKEND=x11` to force GTK/GDK to use Xwayland.
  This avoids a SIGSEGV in libX11.

* Set Java system property `VLCJ_INITX=no` to to disable VLCJ's X initialization
  routine.
  This avoids a SIGSEGV in libpthread.

I've tested that this works as expected with `Video`, `Audio` and `Audio2` elements.

Fixes #6