### PR TITLE
Add Java 17 to tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11' ]
+        java: [ '8', '11', '17' ]
     name: Run Unit Tests on Java ${{ matrix.Java }}
     steps:
       - name: Checkout Code
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.Java }}
       - name: Run Tests
         run: make test

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ or use one of the full releases that include these dependencies.
 
 ## Open Source Software
 Release builds of this application include OpenJDK from AdoptOpenJDK and VLC Media Player
-* AdoptOpenJDK: [Website](https://adoptopenjdk.net/) [Source Code](https://github.com/openjdk/jdk)
+* Adoptium OpenJDK: [Website](https://adoptium.net/) [Source Code](https://github.com/openjdk/jdk)
 * VLC Media Player: [Website](https://www.videolan.org/vlc/index.html) [Source Code](https://www.videolan.org/vlc/download-sources.html)


### PR DESCRIPTION
Adds Java 17 to unit tests and updates source to Temurin(Adoptium) as AdoptOpenJDK is being sunset.